### PR TITLE
Add fixes for Take No Prisoners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,8 @@ wav-winmm.rc.o: wav-winmm.rc.in
 wav-winmm.dll: wav-winmm.c wav-winmm.rc.o wav-winmm.def player.c stubs.c
 	mingw32-gcc -std=gnu99 -Wl,--enable-stdcall-fixup -Ilibs/include -O2 -shared -s -o wav-winmm.dll wav-winmm.c player.c stubs.c wav-winmm.def wav-winmm.rc.o -L. -lvorbisfile-3 -lwinmm -static-libgcc
 
+wav-winmm-debug.dll: wav-winmm.c wav-winmm.rc.o wav-winmm.def player.c stubs.c
+	mingw32-gcc -std=gnu99 -Wl,--enable-stdcall-fixup -Ilibs/include -O2 -shared -s -o wav-winmm-debug.dll -D _DEBUG wav-winmm.c player.c stubs.c wav-winmm.def wav-winmm.rc.o -L. -lvorbisfile-3 -lwinmm -static-libgcc
+
 clean:
 	rm -f wav-winmm.dll wav-winmm.rc.o

--- a/wav-winmm.c
+++ b/wav-winmm.c
@@ -500,6 +500,7 @@ MCIERROR WINAPI fake_mciSendCommandA(MCIDEVICEID IDDevice, UINT uMsg, DWORD_PTR 
                 if (parms->dwItem == MCI_STATUS_READY)
                 {
                     dprintf("      MCI_STATUS_READY\r\n");
+                    parms->dwReturn = (numTracks > 0);
                 }
 
                 if (parms->dwItem == MCI_STATUS_TIME_FORMAT)

--- a/wav-winmm.c
+++ b/wav-winmm.c
@@ -75,6 +75,9 @@ int player_main()
         {
             first = info.first;
             last = info.last;
+            // Force last to be NON-inclusive.
+            if (last == first)
+                last++;
             current = first;
             updateTrack = 0;
         }


### PR DESCRIPTION
Take No Prisoners uses MCI_STATUS_READY's dwReturn value, which wasn't being set.

The game also uses MCI_FORMAT_TMSF with dwFrom being the track's start time and dwTo being the track's end time, resulting in info.first == info.last and stopping music playback before it begins.  I added a condition to set info.last to be info.first + 1 when this occurs so info.last is NON-inclusive.