### PR TITLE
Add fixes for Take No Prisoners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,8 @@ wav-winmm.rc.o: wav-winmm.rc.in
 wav-winmm.dll: wav-winmm.c wav-winmm.rc.o wav-winmm.def player.c stubs.c
 	mingw32-gcc -std=gnu99 -Wl,--enable-stdcall-fixup -Ilibs/include -O2 -shared -s -o wav-winmm.dll wav-winmm.c player.c stubs.c wav-winmm.def wav-winmm.rc.o -L. -lvorbisfile-3 -lwinmm -static-libgcc
 
+wav-winmm-debug.dll: wav-winmm.c wav-winmm.rc.o wav-winmm.def player.c stubs.c
+	mingw32-gcc -std=gnu99 -Wl,--enable-stdcall-fixup -Ilibs/include -O2 -shared -s -o wav-winmm-debug.dll -D _DEBUG wav-winmm.c player.c stubs.c wav-winmm.def wav-winmm.rc.o -L. -lvorbisfile-3 -lwinmm -static-libgcc
+
 clean:
 	rm -f wav-winmm.dll wav-winmm.rc.o

--- a/wav-winmm.c
+++ b/wav-winmm.c
@@ -400,11 +400,12 @@ MCIERROR WINAPI fake_mciSendCommandA(MCIDEVICEID IDDevice, UINT uMsg, DWORD_PTR 
                 else
                     info.last = parms->dwTo;
 
-                if (info.last < info.first)
-                    info.last = info.first;
+                // Keep info.last NON-inclusive.
+                if (info.last <= info.first)
+                    info.last = info.first + 1;
 
-                if (info.last > lastTrack)
-                    info.last = lastTrack;
+                if (info.last > lastTrack + 1)
+                    info.last = lastTrack + 1;
             }
 
             if (info.first && (fdwCommand & MCI_FROM))

--- a/wav-winmm.c
+++ b/wav-winmm.c
@@ -500,6 +500,7 @@ MCIERROR WINAPI fake_mciSendCommandA(MCIDEVICEID IDDevice, UINT uMsg, DWORD_PTR 
                 if (parms->dwItem == MCI_STATUS_READY)
                 {
                     dprintf("      MCI_STATUS_READY\r\n");
+                    parms->dwReturn = (numTracks > 0);
                 }
 
                 if (parms->dwItem == MCI_STATUS_TIME_FORMAT)

--- a/wav-winmm.c
+++ b/wav-winmm.c
@@ -327,7 +327,9 @@ MCIERROR WINAPI fake_mciSendCommandA(MCIDEVICEID IDDevice, UINT uMsg, DWORD_PTR 
                 // FIXME: rounding to nearest track
                 if (time_format == MCI_FORMAT_TMSF)
                 {
-                    info.first = MCI_TMSF_TRACK(parms->dwFrom);
+                    // When dwFrom is 0, keep previously set info.
+                    if (parms->dwFrom)
+                        info.first = MCI_TMSF_TRACK(parms->dwFrom);
 
                     dprintf("      TRACK  %d\n", MCI_TMSF_TRACK(parms->dwFrom));
                     dprintf("      MINUTE %d\n", MCI_TMSF_MINUTE(parms->dwFrom));
@@ -370,7 +372,9 @@ MCIERROR WINAPI fake_mciSendCommandA(MCIDEVICEID IDDevice, UINT uMsg, DWORD_PTR 
 
                 if (time_format == MCI_FORMAT_TMSF)
                 {
-                    info.last = MCI_TMSF_TRACK(parms->dwTo);
+                    // When dwTo is 0, keep previously set info.
+                    if (parms->dwTo)
+                        info.last = MCI_TMSF_TRACK(parms->dwTo);
 
                     dprintf("      TRACK  %d\n", MCI_TMSF_TRACK(parms->dwTo));
                     dprintf("      MINUTE %d\n", MCI_TMSF_MINUTE(parms->dwTo));

--- a/wav-winmm.c
+++ b/wav-winmm.c
@@ -388,7 +388,7 @@ MCIERROR WINAPI fake_mciSendCommandA(MCIDEVICEID IDDevice, UINT uMsg, DWORD_PTR 
                     for (int i = info.first; i < MAX_TRACKS; i++)
                     {
                         // FIXME: use better matching
-                        if (tracks[i].position + tracks[i].length > parms->dwFrom / 1000)
+                        if (tracks[i].position + tracks[i].length > parms->dwTo / 1000)
                         {
                             info.last = i;
                             break;

--- a/wav-winmm.c
+++ b/wav-winmm.c
@@ -75,6 +75,9 @@ int player_main()
         {
             first = info.first;
             last = info.last;
+            // Force last to be NON-inclusive.
+            if (last == first)
+                last++;
             current = first;
             updateTrack = 0;
         }


### PR DESCRIPTION
Take No Prisoners uses MCI_STATUS_READY's dwReturn value, which wasn't being set.

The game also uses MCI_FORMAT_TMSF with dwFrom being the track's start time and dwTo being the track's end time, resulting in info.first == info.last and stopping music playback before it begins. I added a condition to set info.last to be info.first + 1 when this occurs so info.last is NON-inclusive.